### PR TITLE
Migrates experimental integration into a scope decorator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,20 @@
     <opencensus.version>0.14.0</opencensus.version>
     <spring.build.version>2.0.0.RELEASE</spring.build.version>
     <spring.gcp.version>1.0.0.M3</spring.gcp.version>
+    <brave.version>5.2.0</brave.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave-bom</artifactId>
+        <version>${brave.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/spring_brave/src/main/java/io/opencensus/spring/brave/OpenCensusBraveAutoConfiguration.java
+++ b/spring_brave/src/main/java/io/opencensus/spring/brave/OpenCensusBraveAutoConfiguration.java
@@ -16,7 +16,7 @@
 
 package io.opencensus.spring.brave;
 
-import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -24,7 +24,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Role;
 
 /**
@@ -38,9 +37,9 @@ import org.springframework.context.annotation.Role;
 @EnableConfigurationProperties(OpenCensusBraveProperties.class)
 public class OpenCensusBraveAutoConfiguration {
 
+  // once sleuth injects a list of these, it should work intuitively!
   @Bean
-  @Primary
-  CurrentTraceContext openCensusCurrentTraceContext() {
-    return OpenCensusBraveCurrentTraceContext.create();
+  ScopeDecorator openCensusScopeDecorator() {
+    return new OpenCensusBraveScopeDecorator();
   }
 }


### PR DESCRIPTION
This should allow the integration to not clash with other context setup.
It won't work until the integration below exists:

See https://github.com/spring-cloud/spring-cloud-sleuth/issues/1063